### PR TITLE
Add functions 'set_loudness' and 'equal_loudness'

### DIFF
--- a/pyloudness/__init__.py
+++ b/pyloudness/__init__.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 
 def get_loudness(file_location):
     command = ['ffmpeg', '-nostats', '-i', file_location,  '-filter_complex', 'ebur128=peak=true', '-f', 'null', '-']
@@ -27,3 +28,31 @@ def get_loudness(file_location):
     stats['True Peak'] = {}
     stats['True Peak']['Peak'] = float(true_peak_Peak)
     return stats
+
+def set_loudness(file_location, loudness_in_dB=-23, ignore_clipping=False):
+    # calculate gain needed such that integrated loudness is equal to loudness_in_dB
+    stats = get_loudness(file_location)
+    gain_in_dB = loudness_in_dB - stats['Integrated Loudness']['I']
+    linear_gain = pow(10,gain_in_dB/20)
+    # output file name (e.g. 'inputfilename_-23LUFS.wav')
+    output_file = '.'.join(file_location.split('.')[:-1])+'_'+str(loudness_in_dB)+'LUFS.'+\
+                    file_location.split('.')[-1]
+    # warning if clipping
+    command = ['ffmpeg', '-i', file_location, '-af', 'astats', '-f', 'null', '-'] # get stats
+    output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+    peak = float(output.split('Peak level dB: ')[-1].split('\n')[0]) # take last, overall peak
+    assert peak<=0.0, 'Peak allegedly positive (dB)'
+    if peak + gain_in_dB >= 0.0: # check if clipping (liberally)
+        if ignore_clipping:
+            print 'WARNING: '+output_file+' clipped on writing!'
+        else:
+            print file_location+' would clip if gain applied to reach '+str(loudness_in_dB)+' LUFS; skipping!'
+            return # skip, don't apply gain
+    # apply gain
+    command = ['ffmpeg', '-y', '-i', file_location,  '-af', 'volume='+str(linear_gain), output_file]
+    _ = subprocess.check_output(command, stderr=subprocess.STDOUT) # apply gain; don't print ffmpeg output
+    
+def equal_loudness(folder_location, loudness_in_dB=-23, ignore_clipping=False):
+    for file_name in os.listdir(folder_location):
+        if not file_name.startswith('.'):
+            set_loudness(os.path.join(folder_location,file_name), loudness_in_dB, ignore_clipping)


### PR DESCRIPTION
set_loudness creates a scaled version of the specified file with specified EBU R 128 loudness. 
Use: set_loudness(file_location, loudness_in_dB=-23, ignore_clipping=False)
equal_loudness calls set_loudness for all files in a specified folder, with the same loudness. 
Use: equal_loudness(folder_location, loudness_in_dB=-23, ignore_clipping=False)

Not at all necessary, it takes away from the simplicity of the original but it implements a very common loudness-related task (i.e. scaling an audio or video file to a certain loudness). 
