### PR TITLE
Changed encoding output to uft8.

### DIFF
--- a/pyloudness/__init__.py
+++ b/pyloudness/__init__.py
@@ -4,7 +4,7 @@ import os
 
 def get_loudness(file_location):
     command = ['ffmpeg', '-nostats', '-i', file_location,  '-filter_complex', 'ebur128=peak=true', '-f', 'null', '-']
-    output = subprocess.check_output(command, stderr=subprocess.STDOUT, universal_newlines=True)
+    output = subprocess.check_output(command, stderr=subprocess.STDOUT, universal_newlines=True, encoding='utf8')
     summary = output.split("Summary:")[-1]
     output = None
     integrated_loudness = summary.split("Integrated loudness:",1)[1].split("Loudness range:",1)[0]


### PR DESCRIPTION
Using python 3.6, the return from subprocess.check_output by default is a bytes object, which causes an error when using split. Specifying the encoding as utf8 resolves. 