### PR TITLE
Edit __init__.py with utf8 encode to fix TypeError

### DIFF
--- a/pyloudness/__init__.py
+++ b/pyloudness/__init__.py
@@ -5,7 +5,7 @@ import os
 def get_loudness(file_location):
     command = ['ffmpeg', '-nostats', '-i', file_location,  '-filter_complex', 'ebur128=peak=true', '-f', 'null', '-']
     output = subprocess.check_output(command, stderr=subprocess.STDOUT, universal_newlines=True)
-    summary = output.split("Summary:")[-1]
+    summary = output.decode('utf8').split("Summary:")[-1]
     output = None
     integrated_loudness = summary.split("Integrated loudness:",1)[1].split("Loudness range:",1)[0]
     integrated_loudness_I = integrated_loudness.split("I:",1)[1].split("Threshold:",1)[0].split("LUFS",1)[0].strip()


### PR DESCRIPTION
        Changed line 8:
        summary = output.split("Summary:")[-1]
    to
        summary = output.decode('utf8').split("Summary:")[-1]

    This is in response to the error:
    TypeError: a bytes-like object is required, not 'str' on line 8 of __init__.py
	
	It appears to be a change in python in version 3
    Part of the story is here:
    https://docs.python.org/3/howto/pyporting.html
    see "Text versus binary data"
    
    There is another branch that achieves this by specifying utf8 output from the subprocess.  Both work.  I am not sure of best practice.

    -RB